### PR TITLE
wininstaller fix: create missing folder install_node/plugins/

### DIFF
--- a/release-wininstaller
+++ b/release-wininstaller
@@ -142,6 +142,7 @@ if [[ -z "$gitVersion" ]]; then echo Could not get git version; exit 1; fi
 
 # Copy files
 
+mkdir -p "install_node/plugins/"
 cp "$releaseDir/freenet.jar"                         "install_node/"                || exit
 cp "$freenetExtPath"                                 "install_node/freenet-ext.jar" || exit
 cp "$releaseDir/dependencies/bcprov-jdk15on-152.jar" "install_node/"                || exit


### PR DESCRIPTION
missing this folder structure breaks ./release-build buildnumber for me.